### PR TITLE
Fixed mongo authentication

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,8 @@ spring:
   data:
     mongodb:
       ### default: 원격 서버 docker 접속
-      uri: mongodb://spring_user:112233@192.168.0.20/spring_database
+      uri: mongodb://spring_user:112233@localhost/spring_database
+      authentication-database: spring_user
     rest:
       base-path: /api
     jpa:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,9 +12,11 @@ spring:
     initialization-mode: always
   data:
     mongodb:
+      ### for docker-local-mongodb
+#      uri: mongodb://spring_user:112233@localhost/spring_database
       ### default: 원격 서버 docker 접속
-      uri: mongodb://spring_user:112233@localhost/spring_database
-      authentication-database: spring_user
+      uri: mongodb://spring_user:112233@192.168.0.20/spring_database
+      authentication-database: spring_database
     rest:
       base-path: /api
     jpa:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,16 +8,12 @@ spring:
           google:
             client-id: 411922572522-amjb41f97ahgnbq06jiicm13pt33nrg6.apps.googleusercontent.com
             client-secret: NP3ICbi4VpnrAAdUS5aAgK4u
-
   datasource:
     initialization-mode: always
   data:
     mongodb:
       ### default: 원격 서버 docker 접속
-      uri: mongodb://192.168.0.20:27017
-      database: spring_mongodb
-      username: mongoadmin
-      password: 112233
+      uri: mongodb://spring_user:112233@192.168.0.20/spring_database
     rest:
       base-path: /api
     jpa:

--- a/src/test/java/net/hiskarma/stellarTest/Dummy.java
+++ b/src/test/java/net/hiskarma/stellarTest/Dummy.java
@@ -2,29 +2,11 @@ package net.hiskarma.stellarTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.net.URI;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-
 @RunWith(SpringJUnit4ClassRunner.class)
-//@SpringApplicationConfiguration(GoogleSecureApplication.class)
-//@WebIntegrationTest(randomPort = true)
-@DirtiesContext
 public class Dummy {
-    @Value("${local.server.port}")
-    private int port;
-
-    @Test
-    public void contextLoads() {
-    }
+//    @Test
+//    public void contextLoads() {
+//    }
 }


### PR DESCRIPTION
usage prefare setting docker-local-mongo

First. Create docker network
`docker network create spring-network`

Docker run mongodb instantly 
```
docker run --name docker-mongodb \
--network=spring-network \
-v ${somewhere-user-home}/datadir:/data/db \
-p 27017:27017 \
-e MONGO_INITDB_ROOT_USERNAME=mongoadmin \
-e MONGO_INITDB_ROOT_PASSWORD=112233 \
-d mongo
```

Create database and user

```
root@localhost/ mongo admin -u mongoadmin -p '112233' --authenticationDatabase admin
> use spring_database
> db.createUser({user:"spring_user",pwd:"112233","roles":[{"role":"readWrite","db":"spring_database"}]})
```


